### PR TITLE
Editor role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laya-iraq-backend",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "main": "server/server.js",
   "engines": {
     "node": "9.11.x"

--- a/server/boot/02-update-sqlite-schema.js
+++ b/server/boot/02-update-sqlite-schema.js
@@ -18,6 +18,8 @@ const base = [
 const custom = [
   'Account',
   // 'AssessmentScmc',
+  'AuthorApplication',
+  'AuthorApplicationVote',
   'Course',
   // 'CourseQuiz',
   // 'CourseQuizContent',

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -19,14 +19,7 @@
   },
   "AccessToken": {
     "dataSource": "sqlite",
-    "public": false,
-    "relations": {
-      "account": {
-        "type": "belongsTo",
-        "model": "Account",
-        "foreignKey": "accountId"
-      }
-    }
+    "public": false
   },
   "User": {
     "dataSource": "sqlite",
@@ -102,5 +95,13 @@
   },
   "Email": {
     "dataSource": "mail"
+  },
+  "AuthorApplication": {
+    "dataSource": "sqlite",
+    "public": true
+  },
+  "AuthorApplicationVote": {
+    "dataSource": "sqlite",
+    "public": true
   }
 }

--- a/server/models/account.js
+++ b/server/models/account.js
@@ -227,6 +227,34 @@ module.exports = (Account) => {
   };
 
   /**
+   * function editorNo: return number of editors
+   *
+   * Author: cmc
+   *
+   * Last Updated: May 1, 2022
+   * @param cb callback
+   */
+  Account.editorNo = (cb) => {
+    const {Role, RoleMapping} = Account.app.models;
+    Role.findOne({where: {name: 'editor'}}, (err, roleInstance) => {
+      if (err) {
+        cb(err);
+      } else {
+        const editorRoleId = roleInstance.id;
+        RoleMapping.find({where: {principalType: 'USER', roleId: editorRoleId}},
+          (err, roles) => {
+            if (err) {
+              cb(err);
+            } else {
+              cb(null, roles.length);
+            }
+          }
+        );
+      }
+    });
+  };
+
+  /**
    * Function existsByEmail: checks if user email exists
    *
    * Author: core
@@ -490,6 +518,18 @@ module.exports = (Account) => {
       type: 'boolean',
     },
     description: 'Delete User and corresponding role mapping',
+  });
+
+  Account.remoteMethod('editorNo', {
+    http: {
+      path: '/editors',
+      verb: 'get',
+    },
+    returns: {
+      arg: 'editors',
+      type: 'number',
+    },
+    description: 'Returns number of editors in database',
   });
 
   Account.remoteMethod('existsByEmail', {

--- a/server/models/account.json
+++ b/server/models/account.json
@@ -79,6 +79,13 @@
     {
       "accessType": "EXECUTE",
       "principalType": "ROLE",
+      "principalId": "editor",
+      "permission": "ALLOW",
+      "property": "editorNo"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
       "principalId": "$owner",
       "permission": "ALLOW",
       "property": [

--- a/server/models/account.json
+++ b/server/models/account.json
@@ -10,17 +10,16 @@
     "prefs": {
       "type": "object",
       "default": {
-          "media": {
-            "audio": true,
-            "simple": true,
-            "text": true,
-            "video": true
-
-          },
-          "font": {
-            "chosen": "standard",
-            "size": 18
-          }
+        "media": {
+          "audio": true,
+          "simple": true,
+          "text": true,
+          "video": true
+        },
+        "font": {
+          "chosen": "standard",
+          "size": 18
+        }
       }
     },
     "lang": {

--- a/server/models/author-application-vote.js
+++ b/server/models/author-application-vote.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = (AuthorApplicationVote) => {
+  /**
+   * beforeRemote('create'): check if app vote is duplicate
+   *
+   * Author: cmc
+   *
+   * Last Updated: April 26, 2022
+   */
+  AuthorApplicationVote.beforeRemote('create', (ctx, instance, next) => {
+    const {editorId, applicationId} = ctx.args.data;
+    AuthorApplicationVote.findOne({where: {
+      editorId: editorId,
+      applicationId: applicationId,
+    }}, (err, appVote) => {
+      if (err) {
+        next(err);
+      } else {
+        if (appVote) {
+          next(new Error('Vote already exists!'));
+        } else {
+          next();
+        }
+      }
+    });
+  });
+};

--- a/server/models/author-application-vote.js
+++ b/server/models/author-application-vote.js
@@ -17,7 +17,9 @@ module.exports = (AuthorApplicationVote) => {
         next(err);
       } else {
         if (appVote) {
-          next(new Error('Vote already exists!'));
+          const error = new Error('Vote already exists!');
+          error.status = 403;
+          next(error);
         } else {
           next();
         }
@@ -73,7 +75,7 @@ module.exports = (AuthorApplicationVote) => {
   // expose updateVote to API
   AuthorApplicationVote.remoteMethod('updateVote', {
     http: {
-      path: '/:id/updateVote',
+      path: '/:id/update-vote',
       verb: 'patch',
     },
     accepts: [{

--- a/server/models/author-application-vote.js
+++ b/server/models/author-application-vote.js
@@ -24,4 +24,71 @@ module.exports = (AuthorApplicationVote) => {
       }
     });
   });
+
+  /**
+   * updateVote: change vote, push old decision to edited, update date
+   *
+   * Author: cmc
+   *
+   * Last Updated: April 30, 2022
+   * @param {string} id vote ID
+   * @param {boolean} newVote updated vote
+   * @param cb callback
+   */
+  AuthorApplicationVote.updateVote = (id, newVote, cb) => {
+    AuthorApplicationVote.findById(id, (err, instance) => {
+      if (err) {
+        // console.error(err);
+        cb(err);
+      } else if (!instance) {
+        const error = new Error('No Vote with this ID!');
+        error.status = 404;
+        cb(error);
+      } else {
+        // console.log(instance);
+        if (!instance.edited) {
+          instance.edited = [];
+        }
+        const oldVote = {
+          date: instance.date,
+          vote: instance.vote,
+        };
+        // console.log(oldVote);
+        instance.updateAttributes({
+          edited: [...instance.edited, oldVote],
+          date: Date.now(),
+          vote: newVote,
+        }, (err, newInstance) => {
+          // console.log(newInstance);
+          if (err) {
+            cb(err);
+          } else {
+            cb(null, newInstance);
+          }
+        });
+      }
+    });
+  };
+
+  // expose updateVote to API
+  AuthorApplicationVote.remoteMethod('updateVote', {
+    http: {
+      path: '/:id/updateVote',
+      verb: 'patch',
+    },
+    accepts: [{
+      arg: 'id',
+      type: 'string',
+      required: true,
+    }, {
+      arg: 'newVote',
+      type: 'boolean',
+      required: true,
+    }],
+    returns: {
+      arg: 'editorVote',
+      type: 'AuthorApplicationVote',
+    },
+    description: 'Update the vote, save older vote in edited.',
+  });
 };

--- a/server/models/author-application-vote.json
+++ b/server/models/author-application-vote.json
@@ -46,6 +46,12 @@
       "principalType": "ROLE",
       "principalId": "editor",
       "permission": "ALLOW"
+    },
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "admin",
+      "permission": "ALLOW"
     }
   ],
   "methods": {}

--- a/server/models/author-application-vote.json
+++ b/server/models/author-application-vote.json
@@ -31,10 +31,7 @@
     "application": {
       "type": "belongsTo",
       "model": "AuthorApplication",
-      "foreignKey": "",
-      "options": {
-        "nestRemoting": true
-      }
+      "foreignKey": ""
     }
   },
   "acls": [
@@ -47,7 +44,7 @@
     {
       "accessType": "*",
       "principalType": "ROLE",
-      "principalId": "$authenticated",
+      "principalId": "editor",
       "permission": "ALLOW"
     }
   ],

--- a/server/models/author-application-vote.json
+++ b/server/models/author-application-vote.json
@@ -1,0 +1,55 @@
+{
+  "name": "AuthorApplicationVote",
+  "plural": "editor-votes",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "date": {
+      "type": "date",
+      "default": "$now"
+    },
+    "edited": {
+      "type": "array",
+      "default": null
+    },
+    "vote": {
+      "type": "boolean",
+      "required": true,
+      "default": false
+    }
+  },
+  "validations": [],
+  "relations": {
+    "editor": {
+      "type": "belongsTo",
+      "model": "Account",
+      "foreignKey": ""
+    },
+    "application": {
+      "type": "belongsTo",
+      "model": "AuthorApplication",
+      "foreignKey": "",
+      "options": {
+        "nestRemoting": true
+      }
+    }
+  },
+  "acls": [
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "DENY"
+    },
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$authenticated",
+      "permission": "ALLOW"
+    }
+  ],
+  "methods": {}
+}

--- a/server/models/author-application.js
+++ b/server/models/author-application.js
@@ -1,0 +1,27 @@
+'use strict';
+module.exports = (AuthorApplication) => {
+  /**
+   * beforeRemote('create'): check if application for user already exists
+   *
+   * Author: cmc
+   *
+   * Last Updated: May 1, 2022
+   */
+  AuthorApplication.beforeRemote('create', (ctx, instance, next) => {
+    AuthorApplication.findOne({where: {
+      applicantId: ctx.args.data.applicantId,
+    }}, (err, application) => {
+      if (err) {
+        next(err);
+      } else {
+        if (application) {
+          const error = new Error('User has already sent an application!');
+          error.status = 403;
+          next(error);
+        } else {
+          next();
+        }
+      }
+    });
+  });
+};

--- a/server/models/author-application.js
+++ b/server/models/author-application.js
@@ -24,4 +24,71 @@ module.exports = (AuthorApplication) => {
       }
     });
   });
+
+  AuthorApplication.editApplication = (id, data, cb) => {
+    AuthorApplication.findById(id, (err, application) => {
+      if (err) {
+        cb(err);
+      } else if (application) {
+        const editedData = {
+          editTime: Date.parse(application.lastEdited),
+          areaOfExpertise:
+            application.areaOfExpertise === data.areaOfExpertise ?
+              null : application.areaOfExpertise,
+          applicationText:
+            application.applicationText === data.applicationText ?
+              null : application.applicationText,
+          fullName: application.fullName === data.fullName ?
+            null : application.fullName,
+          institution: application.institution === data.institution ?
+            null : application.institution,
+        };
+        Object.keys(editedData).forEach(
+          (k) =>
+            editedData[k] == null && delete editedData[k]
+        ); // strip null values from editedData
+        console.log(editedData);
+        application.updateAttributes({
+          areaOfExpertise: editedData.areaOfExpertise ?
+            data.areaOfExpertise : application.areaOfExpertise,
+          applicationText: editedData.applicationText ?
+            data.applicationText : application.applicationText,
+          edited: application.edited ?
+            [... application.edited, editedData] : [editedData],
+          fullName: editedData.fullName ?
+            data.fullName : application.fullName,
+          institution: editedData.institution ?
+            data.institution : application.institution,
+          lastEdited: Date.now(),
+        });
+        cb(null, application);
+      } else {
+        const err = new Error('Application doesn`t exist!');
+        err.status = 404;
+        cb(err);
+      }
+    });
+  };
+
+  AuthorApplication.remoteMethod('editApplication', {
+    http: {
+      path: '/:id/edit',
+      verb: 'patch',
+    },
+    accepts: [{
+      arg: 'id',
+      type: 'string',
+      required: true,
+    }, {
+      arg: 'newApplication',
+      type: 'object',
+      http: {source: 'body'},
+      required: true,
+    }],
+    returns: {
+      arg: 'editedApplication',
+      type: 'AuthorApplication',
+    },
+    description: 'Update the application, save edits in edited.',
+  });
 };

--- a/server/models/author-application.js
+++ b/server/models/author-application.js
@@ -33,7 +33,7 @@ module.exports = (AuthorApplication) => {
    * Last Updated: May 6, 2022
    * @param id id of application
    * @param decidedOn date of decision
-   * @param status one of 'accepted', 'refused', 'withdrawn'
+   * @param status one of 'accepted', 'rejected', 'withdrawn'
    * @param cb callback
    */
   AuthorApplication.decideOnApplication = (id, {decidedOn, status}, cb) => {
@@ -47,7 +47,7 @@ module.exports = (AuthorApplication) => {
           cb(err);
         } else if (status !== 'withdrawn' &&
           status !== 'accepted' &&
-          status !== 'refused') { // reject if decision has wrong value
+          status !== 'rejected') { // reject if decision has wrong value
           const err = new Error('Wrong decision string!');
           err.status = 403;
           cb(err);

--- a/server/models/author-application.js
+++ b/server/models/author-application.js
@@ -98,20 +98,21 @@ module.exports = (AuthorApplication) => {
           (k) =>
             editedData[k] == null && delete editedData[k]
         ); // strip null values from editedData
-        console.log(editedData);
-        application.updateAttributes({
-          areaOfExpertise: editedData.areaOfExpertise ?
-            data.areaOfExpertise : application.areaOfExpertise,
-          applicationText: editedData.applicationText ?
-            data.applicationText : application.applicationText,
-          edited: application.edited ?
-            [... application.edited, editedData] : [editedData],
-          fullName: editedData.fullName ?
-            data.fullName : application.fullName,
-          institution: editedData.institution ?
-            data.institution : application.institution,
-          lastEdited: Date.now(),
-        });
+        if (Object.keys(editedData).length > 1) {
+          application.updateAttributes({
+            areaOfExpertise: editedData.areaOfExpertise ?
+              data.areaOfExpertise : application.areaOfExpertise,
+            applicationText: editedData.applicationText ?
+              data.applicationText : application.applicationText,
+            edited: application.edited ?
+              [...application.edited, editedData] : [editedData],
+            fullName: editedData.fullName ?
+              data.fullName : application.fullName,
+            institution: editedData.institution ?
+              data.institution : application.institution,
+            lastEdited: Date.now(),
+          });
+        }
         cb(null, application);
       } else {
         const err = new Error('Application doesn`t exist!');

--- a/server/models/author-application.json
+++ b/server/models/author-application.json
@@ -12,16 +12,13 @@
       "default": "$now"
     },
     "areaOfExpertise": {
-      "type": "string",
-      "default": null
+      "type": "string"
     },
     "institution": {
-      "type": "string",
-      "default": null
+      "type": "string"
     },
     "fullName": {
-      "type": "string",
-      "default": null
+      "type": "string"
     },
     "applicationText": {
       "type": "string",
@@ -32,16 +29,13 @@
       "id": true
     },
     "edited": {
-      "type": "array",
-      "default": null
+      "type": "array"
     },
-    "decided": {
-      "type": "boolean",
-      "default": false
+    "accepted": {
+      "type": "boolean"
     },
     "decidedOn": {
-      "type": "date",
-      "default": "null"
+      "type": "date"
     }
   },
   "validations": [],

--- a/server/models/author-application.json
+++ b/server/models/author-application.json
@@ -31,8 +31,9 @@
     "edited": {
       "type": "array"
     },
-    "accepted": {
-      "type": "boolean"
+    "status": {
+      "type": "string",
+      "default": null
     },
     "decidedOn": {
       "type": "date"

--- a/server/models/author-application.json
+++ b/server/models/author-application.json
@@ -11,7 +11,15 @@
       "type": "date",
       "default": "$now"
     },
-    "aoe": {
+    "areaOfExpertise": {
+      "type": "string",
+      "default": null
+    },
+    "institution": {
+      "type": "string",
+      "default": null
+    },
+    "fullName": {
       "type": "string",
       "default": null
     },
@@ -26,6 +34,14 @@
     "edited": {
       "type": "array",
       "default": null
+    },
+    "decided": {
+      "type": "boolean",
+      "default": false
+    },
+    "decidedOn": {
+      "type": "date",
+      "default": "null"
     }
   },
   "validations": [],

--- a/server/models/author-application.json
+++ b/server/models/author-application.json
@@ -7,7 +7,7 @@
     "validateUpsert": true
   },
   "properties": {
-    "created": {
+    "lastEdited": {
       "type": "date",
       "default": "$now"
     },

--- a/server/models/author-application.json
+++ b/server/models/author-application.json
@@ -1,0 +1,54 @@
+{
+  "name": "AuthorApplication",
+  "plural": "applications",
+  "base": "PersistedModel",
+  "idInjection": true,
+  "options": {
+    "validateUpsert": true
+  },
+  "properties": {
+    "created": {
+      "type": "date",
+      "default": "$now"
+    },
+    "aoe": {
+      "type": "string",
+      "default": null
+    },
+    "applicationText": {
+      "type": "string",
+      "required": true
+    },
+    "id": {
+      "type": "number",
+      "id": true
+    },
+    "edited": {
+      "type": "array",
+      "default": null
+    }
+  },
+  "validations": [],
+  "relations": {
+    "applicant": {
+      "type": "belongsTo",
+      "model": "Account",
+      "foreignKey": ""
+    }
+  },
+  "acls": [
+    {
+      "accessType": "*",
+      "principalType": "ROLE",
+      "principalId": "$everyone",
+      "permission": "DENY"
+    },
+    {
+      "accessType": "EXECUTE",
+      "principalType": "ROLE",
+      "principalId": "$authenticated",
+      "permission": "ALLOW"
+    }
+  ],
+  "methods": {}
+}

--- a/server/models/flag.json
+++ b/server/models/flag.json
@@ -29,7 +29,7 @@
       ],
       "default": []
     },
-    "anonymous":  {
+    "anonymous": {
       "type": "boolean",
       "default": false
     }


### PR DESCRIPTION
Created AuthorApplication and AuthorApplicationVote models. Created remote methods for managing author applications.

## What to test
- [ ] POST request to `/applications` works
- [ ] POST request to `/applications` fails when `applicantId` already exists
- [ ] GET request to `/authors/editors` returns correct number of editors
- [ ] POST request to `/applications/:id/decide` sets status of application to given input
- [ ] POST request to `/applications/:id/decide` fails if given input is not one of "accepted", "rejected", "withdrawn"
- [ ] POST request to `/applications/:id/decide` fails if application status is not null
- [ ] PATCH request to `/applications/:id/edit` changes respective values and pushes old values into `edited`
- [ ] POST request to `/editor-votes` fails if vote for specific `editorId` and `applicationId` already exists
- [ ] PATCH request to `/editor-votes` changes vote, pushes old values to `edited` 
- [ ] afterRemote hook after POST `/editor-votes` accepts application after 10 minutes